### PR TITLE
Update biome.base.jsonc

### DIFF
--- a/biome.base.jsonc
+++ b/biome.base.jsonc
@@ -79,7 +79,7 @@
       "jsxQuoteStyle": "double",
       "quoteStyle": "double",
       "quoteProperties": "asNeeded",
-      "trailingCommas": "all",
+      "trailingComma": "all",
       "semicolons": "always",
       "bracketSpacing": true,
       "bracketSameLine": false,


### PR DESCRIPTION
Use trailingComma instead of trailingCommas, otherwise I get error:
```
✖ Found an unknown key `trailingCommas`.

    80 │       "quoteStyle": "double",
    81 │       "quoteProperties": "asNeeded",
  > 82 │       "trailingCommas": "all",
       │       ^^^^^^^^^^^^^^^^
    83 │       "semicolons": "always",
    84 │       "bracketSpacing": true,

  ℹ Known keys:

  - jsxQuoteStyle
  - quoteProperties
  - trailingComma
  - semicolons
  - arrowParentheses
  - bracketSpacing
  - bracketSameLine
  - enabled
  - indentStyle
  - indentWidth
  - lineEnding
  - lineWidth
  - quoteStyle
  - attributePosition
  ```